### PR TITLE
fix: backing size for image node which content mode is scaleAspectFit

### DIFF
--- a/Source/Private/ASImageNode+CGExtras.m
+++ b/Source/Private/ASImageNode+CGExtras.m
@@ -56,11 +56,11 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
 
   size_t destinationWidth = boundsSize.width;
   size_t destinationHeight = boundsSize.height;
-  
+
   // Often, an image is too low resolution to completely fill the width and height provided.
   // Per the API contract as commented in the header, we will adjust input parameters (destinationWidth, destinationHeight) to ensure that the image is not upscaled on the CPU.
   CGFloat boundsAspectRatio = (CGFloat)destinationWidth / (CGFloat)destinationHeight;
-  
+
   CGSize minimumDestinationSize = sourceImageSize;
   BOOL cropToRectDimensions = !CGRectIsEmpty(cropRect);
   
@@ -73,7 +73,7 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
     else if (contentMode == UIViewContentModeScaleAspectFit)
       minimumDestinationSize = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
   }
-  
+
   // If fitting the desired aspect ratio to the image size actually results in a larger buffer, use the input values.
   // However, if there is a pixel savings (e.g. we would have to upscale the image), override the function arguments.
   if (CGSizeEqualToSize(CGSizeZero, forcedSize) == NO) {
@@ -88,11 +88,11 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
       return;
     }
   }
-  
+
   // Figure out the scaled size within the destination bounds.
   CGFloat sourceImageAspectRatio = sourceImageSize.width / sourceImageSize.height;
   CGSize scaledSizeForImage = CGSizeMake(destinationWidth, destinationHeight);
-  
+
   if (cropToRectDimensions) {
     scaledSizeForImage = CGSizeMake(boundsSize.width / cropRect.size.width, boundsSize.height / cropRect.size.height);
   } else {
@@ -101,7 +101,7 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
     else if (contentMode == UIViewContentModeScaleAspectFit)
       scaledSizeForImage = _ASSizeFitWithAspectRatio(sourceImageAspectRatio, scaledSizeForImage);
   }
-  
+
   // Figure out the rectangle into which to draw the image.
   CGRect drawRect = CGRectZero;
   if (cropToRectDimensions) {
@@ -126,7 +126,7 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
                             scaledSizeForImage.height);
     }
   }
-  
+
   *outDrawRect = drawRect;
   *outBackingSize = CGSizeMake(destinationWidth, destinationHeight);
 }

--- a/Source/Private/ASImageNode+CGExtras.m
+++ b/Source/Private/ASImageNode+CGExtras.m
@@ -56,74 +56,82 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
 
   size_t destinationWidth = boundsSize.width;
   size_t destinationHeight = boundsSize.height;
-
+  
   // Often, an image is too low resolution to completely fill the width and height provided.
   // Per the API contract as commented in the header, we will adjust input parameters (destinationWidth, destinationHeight) to ensure that the image is not upscaled on the CPU.
   CGFloat boundsAspectRatio = (CGFloat)destinationWidth / (CGFloat)destinationHeight;
-
-  CGSize scaledSizeForImage = sourceImageSize;
+  
+  CGSize minimumDestinationSize = sourceImageSize;
   BOOL cropToRectDimensions = !CGRectIsEmpty(cropRect);
-
+  
+  // Given image size and container ratio, calculate minimum container size for the image under different contentMode
   if (cropToRectDimensions) {
-    scaledSizeForImage = CGSizeMake(boundsSize.width / cropRect.size.width, boundsSize.height / cropRect.size.height);
+    minimumDestinationSize = CGSizeMake(boundsSize.width / cropRect.size.width, boundsSize.height / cropRect.size.height);
   } else {
+<<<<<<< Updated upstream
     if (contentMode == UIViewContentModeScaleAspectFill || contentMode == UIViewContentModeScaleAspectFit)
       scaledSizeForImage = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
+=======
+    if (contentMode == UIViewContentModeScaleAspectFill)
+      minimumDestinationSize = _ASSizeFitWithAspectRatio(boundsAspectRatio, sourceImageSize);
+    else if (contentMode == UIViewContentModeScaleAspectFit)
+      minimumDestinationSize = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
+>>>>>>> Stashed changes
   }
-
+  
   // If fitting the desired aspect ratio to the image size actually results in a larger buffer, use the input values.
   // However, if there is a pixel savings (e.g. we would have to upscale the image), override the function arguments.
   if (CGSizeEqualToSize(CGSizeZero, forcedSize) == NO) {
     destinationWidth = (size_t)round(forcedSize.width);
     destinationHeight = (size_t)round(forcedSize.height);
-  } else if (forceUpscaling == NO && (scaledSizeForImage.width * scaledSizeForImage.height) < (destinationWidth * destinationHeight)) {
-    destinationWidth = (size_t)round(scaledSizeForImage.width);
-    destinationHeight = (size_t)round(scaledSizeForImage.height);
+  } else if (forceUpscaling == NO && (minimumDestinationSize.width * minimumDestinationSize.height) < (destinationWidth * destinationHeight)) {
+    destinationWidth = (size_t)round(minimumDestinationSize.width);
+    destinationHeight = (size_t)round(minimumDestinationSize.height);
     if (destinationWidth == 0 || destinationHeight == 0) {
       *outBackingSize = CGSizeZero;
       *outDrawRect = CGRectZero;
       return;
     }
   }
-
+  
   // Figure out the scaled size within the destination bounds.
   CGFloat sourceImageAspectRatio = sourceImageSize.width / sourceImageSize.height;
-  CGSize scaledSizeForDestination = CGSizeMake(destinationWidth, destinationHeight);
-
+  CGSize scaledSizeForImage = CGSizeMake(destinationWidth, destinationHeight);
+  
   if (cropToRectDimensions) {
-    scaledSizeForDestination = CGSizeMake(boundsSize.width / cropRect.size.width, boundsSize.height / cropRect.size.height);
+    scaledSizeForImage = CGSizeMake(boundsSize.width / cropRect.size.width, boundsSize.height / cropRect.size.height);
   } else {
     if (contentMode == UIViewContentModeScaleAspectFill)
-      scaledSizeForDestination = _ASSizeFillWithAspectRatio(sourceImageAspectRatio, scaledSizeForDestination);
+      scaledSizeForImage = _ASSizeFillWithAspectRatio(sourceImageAspectRatio, scaledSizeForImage);
     else if (contentMode == UIViewContentModeScaleAspectFit)
-      scaledSizeForDestination = _ASSizeFitWithAspectRatio(sourceImageAspectRatio, scaledSizeForDestination);
+      scaledSizeForImage = _ASSizeFitWithAspectRatio(sourceImageAspectRatio, scaledSizeForImage);
   }
-
+  
   // Figure out the rectangle into which to draw the image.
   CGRect drawRect = CGRectZero;
   if (cropToRectDimensions) {
-    drawRect = CGRectMake(-cropRect.origin.x * scaledSizeForDestination.width,
-                          -cropRect.origin.y * scaledSizeForDestination.height,
-                          scaledSizeForDestination.width,
-                          scaledSizeForDestination.height);
+    drawRect = CGRectMake(-cropRect.origin.x * scaledSizeForImage.width,
+                          -cropRect.origin.y * scaledSizeForImage.height,
+                          scaledSizeForImage.width,
+                          scaledSizeForImage.height);
   } else {
     // We want to obey the origin of cropRect in aspect-fill mode.
     if (contentMode == UIViewContentModeScaleAspectFill) {
-      drawRect = CGRectMake(((destinationWidth - scaledSizeForDestination.width) * cropRect.origin.x),
-                            ((destinationHeight - scaledSizeForDestination.height) * cropRect.origin.y),
-                            scaledSizeForDestination.width,
-                            scaledSizeForDestination.height);
-
+      drawRect = CGRectMake(((destinationWidth - scaledSizeForImage.width) * cropRect.origin.x),
+                            ((destinationHeight - scaledSizeForImage.height) * cropRect.origin.y),
+                            scaledSizeForImage.width,
+                            scaledSizeForImage.height);
+      
     }
     // And otherwise just center it.
     else {
-      drawRect = CGRectMake(((destinationWidth - scaledSizeForDestination.width) / 2.0),
-                            ((destinationHeight - scaledSizeForDestination.height) / 2.0),
-                            scaledSizeForDestination.width,
-                            scaledSizeForDestination.height);
+      drawRect = CGRectMake(((destinationWidth - scaledSizeForImage.width) / 2.0),
+                            ((destinationHeight - scaledSizeForImage.height) / 2.0),
+                            scaledSizeForImage.width,
+                            scaledSizeForImage.height);
     }
   }
-
+  
   *outDrawRect = drawRect;
   *outBackingSize = CGSizeMake(destinationWidth, destinationHeight);
 }

--- a/Source/Private/ASImageNode+CGExtras.m
+++ b/Source/Private/ASImageNode+CGExtras.m
@@ -68,15 +68,10 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
   if (cropToRectDimensions) {
     minimumDestinationSize = CGSizeMake(boundsSize.width / cropRect.size.width, boundsSize.height / cropRect.size.height);
   } else {
-<<<<<<< Updated upstream
-    if (contentMode == UIViewContentModeScaleAspectFill || contentMode == UIViewContentModeScaleAspectFit)
-      scaledSizeForImage = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
-=======
     if (contentMode == UIViewContentModeScaleAspectFill)
       minimumDestinationSize = _ASSizeFitWithAspectRatio(boundsAspectRatio, sourceImageSize);
     else if (contentMode == UIViewContentModeScaleAspectFit)
       minimumDestinationSize = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
->>>>>>> Stashed changes
   }
   
   // If fitting the desired aspect ratio to the image size actually results in a larger buffer, use the input values.

--- a/Source/Private/ASImageNode+CGExtras.m
+++ b/Source/Private/ASImageNode+CGExtras.m
@@ -67,7 +67,8 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
   if (cropToRectDimensions) {
     scaledSizeForImage = CGSizeMake(boundsSize.width / cropRect.size.width, boundsSize.height / cropRect.size.height);
   } else {
-    scaledSizeForImage = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
+    if (contentMode == UIViewContentModeScaleAspectFill || contentMode == UIViewContentModeScaleAspectFit)
+      scaledSizeForImage = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
   }
 
   // If fitting the desired aspect ratio to the image size actually results in a larger buffer, use the input values.

--- a/Source/Private/ASImageNode+CGExtras.m
+++ b/Source/Private/ASImageNode+CGExtras.m
@@ -67,10 +67,7 @@ void ASCroppedImageBackingSizeAndDrawRectInBounds(CGSize sourceImageSize,
   if (cropToRectDimensions) {
     scaledSizeForImage = CGSizeMake(boundsSize.width / cropRect.size.width, boundsSize.height / cropRect.size.height);
   } else {
-    if (contentMode == UIViewContentModeScaleAspectFill)
-      scaledSizeForImage = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
-    else if (contentMode == UIViewContentModeScaleAspectFit)
-      scaledSizeForImage = _ASSizeFitWithAspectRatio(boundsAspectRatio, sourceImageSize);
+    scaledSizeForImage = _ASSizeFillWithAspectRatio(boundsAspectRatio, sourceImageSize);
   }
 
   // If fitting the desired aspect ratio to the image size actually results in a larger buffer, use the input values.


### PR DESCRIPTION
如果把 `ASImageNode` 的 `contentMode` 设为 `.scaleAspectFit`，计算backing size就会有问题，图片就会模糊。

举个例子，一个100x100的图片，我们想以scaleAspectFit的mode渲染在200x400的容器上（这里单位都是像素）。正常逻辑，我们希望backing size在维持容器的比例的前提下能够尽量小到足够画完整个图片，所以这边backing size应该是100x200。drawRect应该维持图片的比例并居中，所以应该是(0, 50, 100, 100)。

但是ASDK的算法有问题，它在算backing size的时候算小了，算成了50x100，而drawRect计算逻辑是“正确的”，算出来是(0, 25, 50, 50)，导致图片更加模糊了。

解决办法是在算backing size的时候根据比例进行size的放大而不是缩小。